### PR TITLE
fix: Instance of MWA can't run more than once.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.idea
+.vscode
+.nova
 .DS_Store
 coverage
 node_modules

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,13 +36,13 @@ export class Mwa<S> {
    * @see {@link https://github.com/koajs/compose/blob/master/index.js}
    */
   run (state: S): Promise<void> {
-    const next = async (): Promise<void> => {
-      const current = this.middlewares.shift()
-      if (current == null) return Promise.resolve()
-      const result = current(state, next)
+    const next = async (idx: number): Promise<void> => {
+      const middleware = this.middlewares[idx]
+      if (middleware == null) return Promise.resolve()
+      const result = middleware(state, () => next(idx + 1))
       return Promise.resolve(result)
     }
-    return next()
+    return next(0)
   }
 
   /**

--- a/test/mwa.test.ts
+++ b/test/mwa.test.ts
@@ -38,7 +38,17 @@ test('middlewares', async () => {
     order.push(8)
   })
 
-  await app.run({ a: 1 })
+  const state1 = { a: 1 }
 
+  await app.run(state1)
+
+  expect(state1).toEqual({ a: 1, b: 2, c: 3, d: 4 })
   expect(order).toEqual([1, 3, 5, 7, 8, 6, 4, 2])
+
+  const state2 = { a: 1, z: -1 }
+
+  await app.run(state2)
+
+  expect(state2).toEqual({ a: 1, b: 2, c: 3, d: 4, z: -1 })
+  expect(order).toEqual([1, 3, 5, 7, 8, 6, 4, 2, 1, 3, 5, 7, 8, 6, 4, 2])
 })


### PR DESCRIPTION
https://github.com/zce/mwa/blob/40b1beb635ccb4eee3049e47058018d6632b5d81/src/index.ts#L40

这行代码会导致 MWA 实例调用 `run()` 方法后，`this.middlewares` 会被清空。因此如果再次调用 `run()` 方法会有问题。